### PR TITLE
fix(wasm): increase stack size to 1MB

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,8 @@ shared_module(
   install: true,
   link_args: common_link_args + [
     '--no-entry',
-    '-sBINARYEN_EXTRA_PASSES=-Os'
+    '-sBINARYEN_EXTRA_PASSES=-Os',
+    '-sSTACK_SIZE=1048576'
   ],
   name_prefix: '',
   name_suffix: 'wasm',


### PR DESCRIPTION
Hi! Thanks for this project so I can finally switch to Typst :)

Just a simple fix to avoid the `out of bounds memory access` error. Emscripten's default stack size is [64KB](https://emscripten.org/docs/tools_reference/settings_reference.html#stack-size) which is apparently not enough for a PDF renderer. 1MB should be well enough.